### PR TITLE
Feature: optional rate limiter on concurrent sitemap functions executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,26 @@
 
 ## 📚 Table Of Contents
 
-- [Getting Started](#-getting-started)
+- [✨ Features](#-features)
+- [📚 Table Of Contents](#-table-of-contents)
+- [🚀 Getting Started](#-getting-started)
   - [Installation](#installation)
   - [Usage](#usage)
     - [Runtime Generation](#runtime-generation)
     - [Build time Generation](#build-time-generation)
-- [Guides](#-guides)
-    - [Generate Sitemap for Dynamic Routes](#generate-sitemap-for-dynamic-routes)
-    - [Exclude Route](#exclude-route)
-    - [Google: News, Image and Video](#google-news-image-and-video)
-    - [Splitting Sitemaps](#splitting-sitemaps)
-    - [Caching](#caching)
-- [API Reference](#-api-reference)
+- [📝 Guides](#-guides)
+  - [Generate Sitemap for Dynamic Routes](#generate-sitemap-for-dynamic-routes)
+  - [Exclude Route](#exclude-route)
+  - [Google: News, Image and Video](#google-news-image-and-video)
+  - [Splitting Sitemaps](#splitting-sitemaps)
+  - [Caching](#caching)
+- [📖 API Reference](#-api-reference)
   - [Config](#config)
+    - [RobotsTxtOptions](#robotstxtoptions)
+- [👤 Author](#-author)
+- [🤝 Contributing](#-contributing)
+- [Show your support](#show-your-support)
+- [Acknowledgements](#acknowledgements)
 
 
 ## 🚀 Getting Started
@@ -254,6 +261,7 @@ createSitemapGenerator({
 - `alternateRefs = []`: (*optional*) default multi language support by unique url for all entries.
 - `generateRobotsTxt = false`: (*optional*) generate `robots.txt` file.
 - `robotsTxtOptions`: (*optional*) options for generating `robots.txt` [details](#RobotsTxtOptions).
+- `rateLimit`: (*optional*) limits the number of `sitemap` functions that can execute at once.
 
 **Runtime only**
 - `headers = {}`: (*optional*) headers for the sitemap and robots.txt response.

--- a/src/builders/sitemap.ts
+++ b/src/builders/sitemap.ts
@@ -155,7 +155,9 @@ async function IngestRoutes(params: GetSitemapParams) {
 
     return (await Promise.all(entriesPromise)).flat().filter(truthy);
   } else {
-    const entriesPromise = routes.map(route => getEntry({ route, config, context, request }));
+    const entriesPromise = routes.map(route =>
+      getEntry({ route, config, context, request
+    }));
 
     return (await Promise.all(entriesPromise)).flat().filter(truthy);
   }

--- a/src/builders/sitemap.ts
+++ b/src/builders/sitemap.ts
@@ -156,8 +156,8 @@ async function IngestRoutes(params: GetSitemapParams) {
     return (await Promise.all(entriesPromise)).flat().filter(truthy);
   } else {
     const entriesPromise = routes.map(route =>
-      getEntry({ route, config, context, request
-    }));
+      getEntry({ route, config, context, request })
+    );
 
     return (await Promise.all(entriesPromise)).flat().filter(truthy);
   }

--- a/src/builders/sitemap.ts
+++ b/src/builders/sitemap.ts
@@ -156,6 +156,7 @@ async function IngestRoutes(params: GetSitemapParams) {
     return (await Promise.all(entriesPromise)).flat().filter(truthy);
   } else {
     const entriesPromise = routes.map(route => getEntry({ route, config, context, request }));
+
     return (await Promise.all(entriesPromise)).flat().filter(truthy);
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,11 @@ export interface RemixSitemapConfig {
   headers?: HeadersInit;
 
   /**
+   * Limit the number of routes processed at a time
+   */
+  rateLimit?: number;
+
+  /**
    * The cache to use.
    */
   cache?: Cache;

--- a/src/utils/__tests__/rate-limiter.test.ts
+++ b/src/utils/__tests__/rate-limiter.test.ts
@@ -1,3 +1,5 @@
+import { RateLimiter } from "../rate-limiter";
+
 describe('RateLimiter', () => {
   it('should not allow more than the rate limit to run concurrently', async () => {
     const limit = new RateLimiter(3);

--- a/src/utils/__tests__/rate-limiter.test.ts
+++ b/src/utils/__tests__/rate-limiter.test.ts
@@ -1,22 +1,29 @@
-import { RateLimiter } from "../rate-limiter";
+import { RateLimiter } from '../rate-limiter';
 
 describe('RateLimiter', () => {
   it('should not allow more than the rate limit to run concurrently', async () => {
     const limit = new RateLimiter(3);
     let activeTasks = 0;
-    const increaseActive = () => { activeTasks++; };
-    const decreaseActive = () => { activeTasks--; limit.free(); };
-    const tasks = Array(5).fill(null).map(async () => {
-      await limit.allocate();
+    const increaseActive = () => {
+      activeTasks++;
+    };
+    const decreaseActive = () => {
+      activeTasks--; limit.free();
+    };
+    const tasks = Array(5)
+      .fill(null).map(async () => {
+        await limit.allocate();
 
-      increaseActive();
-      expect(activeTasks).toBeLessThanOrEqual(3);
+        increaseActive();
+        expect(activeTasks).toBeLessThanOrEqual(3);
 
-       // Mock task duration (randomness to affect completion order)
-      await new Promise(resolve => setTimeout(resolve, 500 + 500*Math.random()));
-      decreaseActive();
-    });
-    await Promise.all(tasks);
+        // Mock task duration (randomness to affect completion order)
+        await new Promise(resolve =>
+          setTimeout(resolve, 500 + 500 * Math.random())
+        );
+        decreaseActive();
+      });
+      await Promise.all(tasks);
   });
 
   it('should queue tasks and execute them in order', async () => {
@@ -27,7 +34,7 @@ describe('RateLimiter', () => {
       taskOrder.push(id);
 
       // Mock task duration (randomness to affect completion order)
-      await new Promise(resolve => setTimeout(resolve, 500 + 500*Math.random()));
+      await new Promise(resolve => setTimeout(resolve, 500));
       limit.free();
     };
 
@@ -45,7 +52,7 @@ describe('RateLimiter', () => {
     };
 
     await Promise.all([mockTask(), mockTask()]);
-    // Check internal state or behavior to ensure it's handling this correctly
-    // This might depend on the implementation details of RateLimiter
+    expect(limit.getProcessing()).toEqual(0);
+    expect(limit.getWaiting()).toEqual(0);
   });
 });

--- a/src/utils/__tests__/rate-limiter.test.ts
+++ b/src/utils/__tests__/rate-limiter.test.ts
@@ -10,7 +10,8 @@ describe('RateLimiter', () => {
     };
 
     const decreaseActive = () => {
-      activeTasks--; limit.free();
+      activeTasks--;
+      limit.free();
     };
 
     const tasks = Array(5)
@@ -32,7 +33,7 @@ describe('RateLimiter', () => {
 
   it('should queue tasks and execute them in order', async () => {
     const limit = new RateLimiter(1);
-    let taskOrder: number[] = [];
+    const taskOrder: number[] = [];
     const mockTask = async (id: number) => {
       await limit.allocate();
 
@@ -68,7 +69,7 @@ describe('RateLimiter', () => {
     await Promise.all(
       Array(100)
         .fill(0)
-        .map(_ => mockTask())
+        .map(() => mockTask())
     );
 
     expect(limit.getProcessing()).toEqual(0);

--- a/src/utils/__tests__/rate-limiter.test.ts
+++ b/src/utils/__tests__/rate-limiter.test.ts
@@ -1,0 +1,49 @@
+describe('RateLimiter', () => {
+  it('should not allow more than the rate limit to run concurrently', async () => {
+    const limit = new RateLimiter(3);
+    let activeTasks = 0;
+    const increaseActive = () => { activeTasks++; };
+    const decreaseActive = () => { activeTasks--; limit.free(); };
+    const tasks = Array(5).fill(null).map(async () => {
+      await limit.allocate();
+
+      increaseActive();
+      expect(activeTasks).toBeLessThanOrEqual(3);
+
+       // Mock task duration (randomness to affect completion order)
+      await new Promise(resolve => setTimeout(resolve, 500 + 500*Math.random()));
+      decreaseActive();
+    });
+    await Promise.all(tasks);
+  });
+
+  it('should queue tasks and execute them in order', async () => {
+    const limit = new RateLimiter(2);
+    let taskOrder = [];
+    const mockTask = async (id) => {
+      await limit.allocate();
+      taskOrder.push(id);
+
+      // Mock task duration (randomness to affect completion order)
+      await new Promise(resolve => setTimeout(resolve, 500 + 500*Math.random()));
+      limit.free();
+    };
+
+    const tasks = [1, 2, 3, 4].map(id => mockTask(id));
+    await Promise.all(tasks);
+    expect(taskOrder).toEqual([1, 2, 3, 4]); // Ensure tasks are executed in the expected order
+  });
+
+  it('should handle rapid calls to free correctly', async () => {
+    const limit = new RateLimiter(1);
+    const mockTask = async () => {
+      await limit.allocate();
+      limit.free();
+      limit.free(); // Intentional rapid call to free
+    };
+
+    await Promise.all([mockTask(), mockTask()]);
+    // Check internal state or behavior to ensure it's handling this correctly
+    // This might depend on the implementation details of RateLimiter
+  });
+});

--- a/src/utils/__tests__/rate-limiter.test.ts
+++ b/src/utils/__tests__/rate-limiter.test.ts
@@ -14,7 +14,8 @@ describe('RateLimiter', () => {
     };
 
     const tasks = Array(5)
-      .fill(null).map(async () => {
+      .fill(null)
+      .map(async () => {
         await limit.allocate();
 
         increaseActive();
@@ -36,7 +37,7 @@ describe('RateLimiter', () => {
       await limit.allocate();
 
       // Make each task successively longer to ensure execution completion order
-      await new Promise(resolve => setTimeout(resolve, 100 + 500 * id));
+      await new Promise(resolve => setTimeout(resolve, 100));
 
       taskOrder.push(id);
       limit.free();
@@ -64,9 +65,10 @@ describe('RateLimiter', () => {
 
       limit.free();
     };
-    await Promise.all(Array(100)
-      .fill(0)
-      .map(_ => mockTask())
+    await Promise.all(
+      Array(100)
+        .fill(0)
+        .map(_ => mockTask())
     );
 
     expect(limit.getProcessing()).toEqual(0);

--- a/src/utils/__tests__/rate-limiter.test.ts
+++ b/src/utils/__tests__/rate-limiter.test.ts
@@ -31,10 +31,11 @@ describe('RateLimiter', () => {
     let taskOrder = [];
     const mockTask = async (id) => {
       await limit.allocate();
-      taskOrder.push(id);
 
       // Mock task duration (randomness to affect completion order)
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise(resolve => setTimeout(resolve, 500 + 500*id));
+
+      taskOrder.push(id);
       limit.free();
     };
 

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -31,7 +31,7 @@ export class RateLimiter {
   }
 
   free(): void {
-    const first = this.queue.pop();
+    const first = this.queue.shift();
     if (first) {
       // Don't change activity count
       // just substitute the finished work with new work

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -40,4 +40,11 @@ export class RateLimiter {
       this.active = Math.max(0, this.active - 1);
     }
   }
+
+  getProcessing(): number {
+    return this.active;
+  }
+  getWaiting(): number {
+    return this.queue.length;
+  }
 }

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -19,9 +19,8 @@ export class RateLimiter {
     this.active = 0;
   }
 
-
   allocate(): Promise<void> {
-    return new Promise((res) => {
+    return new Promise(res => {
       if (this.active < this.rate) {
         this.active++;
         res();
@@ -38,7 +37,7 @@ export class RateLimiter {
       // just substitute the finished work with new work
       first();
     } else {
-      this.active = Math.max(0, this.active-1);
+      this.active = Math.max(0, this.active - 1);
     }
   }
 }

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -1,0 +1,42 @@
+/**
+ * Usage:
+ * const limit = new RateLimiter(3);
+ * Promise.all(arr.map(async x => {
+ *   await limit.allocate(); // waits until there are less than three active
+ *   await longTask(x);
+ *   limit.free();            // mark the task as done, allowing another to start
+ * }))
+ */
+
+export class RateLimiter {
+	rate: number;
+	queue: Array<() => void>;
+	active: number;
+
+	constructor(rate: number) {
+		this.rate = rate;
+		this.queue = [];
+		this.active = 0;
+	}
+
+
+	allocate(): Promise<void> {
+		return new Promise((res) => {
+			if (this.active < this.rate) {
+				this.active++;
+				res();
+			} else {
+				this.queue.push(res);
+			}
+		});
+	}
+
+	free(): void {
+		const first = this.queue.pop();
+		if (first) {
+			first();
+		} else {
+			this.active = Math.max(0, this.active-1);
+		}
+	}
+}

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -4,39 +4,41 @@
  * Promise.all(arr.map(async x => {
  *   await limit.allocate(); // waits until there are less than three active
  *   await longTask(x);
- *   limit.free();            // mark the task as done, allowing another to start
+ *   limit.free();           // mark the task as done, allowing another to start
  * }))
  */
 
 export class RateLimiter {
-	rate: number;
-	queue: Array<() => void>;
-	active: number;
+  rate: number;
+  queue: Array<() => void>;
+  active: number;
 
-	constructor(rate: number) {
-		this.rate = rate;
-		this.queue = [];
-		this.active = 0;
-	}
+  constructor(rate: number) {
+    this.rate = rate;
+    this.queue = [];
+    this.active = 0;
+  }
 
 
-	allocate(): Promise<void> {
-		return new Promise((res) => {
-			if (this.active < this.rate) {
-				this.active++;
-				res();
-			} else {
-				this.queue.push(res);
-			}
-		});
-	}
+  allocate(): Promise<void> {
+    return new Promise((res) => {
+      if (this.active < this.rate) {
+        this.active++;
+        res();
+      } else {
+        this.queue.push(res);
+      }
+    });
+  }
 
-	free(): void {
-		const first = this.queue.pop();
-		if (first) {
-			first();
-		} else {
-			this.active = Math.max(0, this.active-1);
-		}
-	}
+  free(): void {
+    const first = this.queue.pop();
+    if (first) {
+      // Don't change activity count
+      // just substitute the finished work with new work
+      first();
+    } else {
+      this.active = Math.max(0, this.active-1);
+    }
+  }
 }


### PR DESCRIPTION
Adds an optional config property `rateLimit` which restricts the number of `sitemap` functions that can execute concurrently, reducing the potential chances of hitting connection limits on a db.

If no connection limit is set, there is no change to execution behaviour.

I was unable to test this code actually works as there are multiple peer dependecy conflicts preventing me from building the project, however it should thoretically work.

This should also fix issue #61 