### PR TITLE
Proposal: Expose global flags for when running in remix-sitemap cli

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -13,6 +13,7 @@ import {
   deleteOldSitemaps
 } from './files';
 import { pathToFileURL } from 'url';
+import { getFlagsRef } from '../lib/flags';
 
 const findConfig = () => {
   const configPath = path.resolve(process.cwd(), 'remix-sitemap.config.js');
@@ -22,6 +23,9 @@ const findConfig = () => {
 
 async function main() {
   const configPath = findConfig();
+  const flags = getFlagsRef();
+  flags.standalone = true;
+  flags.generating = true;
 
   if (!configPath) {
     console.error('❌ No config file found');
@@ -68,6 +72,8 @@ async function main() {
   createSitemapFiles(sitemap, config);
 
   console.log('✨ Sitemap generated successfully');
+
+  flags.generating = false;
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import type { Config, Routes, EntryContext } from './lib/types';
-import { sitemapResponse } from './sitemap';
 import { isSitemapUrl, isRobotsUrl } from './utils/validations';
-import { getConfig } from './lib/config';
+import { sitemapResponse } from './sitemap';
 import { robotsResponse } from './robots';
+import { getFlagsRef } from './lib/flags';
+import { getConfig } from './lib/config';
 
 export {
   SitemapHandle,
@@ -11,6 +12,9 @@ export {
   SitemapFunction,
   SitemapArgs
 } from './lib/types';
+
+export type FlagsType = ReturnType<typeof getFlagsRef>;
+export const getFlags = () => getFlagsRef() as Readonly<FlagsType>;
 
 export const createSitemapGenerator = (config: Config) => {
   const defaultConfig = getConfig(config);

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,8 @@
+import { singleton } from '../utils/singleton';
+
+const flags = singleton('remix_flags', () => ({
+  standalone: false,
+  generating: false
+}));
+
+export const getFlagsRef = () => flags;

--- a/src/utils/singleton.ts
+++ b/src/utils/singleton.ts
@@ -1,0 +1,16 @@
+declare global {
+  // must be var not let due to variable hoisting
+  var __singletons: Record<string, unknown> | undefined; // eslint-disable-line
+}
+
+export function singleton<T>(name: string, init: () => T): T {
+  if (!global.__singletons) {
+    global.__singletons = {};
+  }
+
+  if (!global.__singletons[name]) {
+    global.__singletons[name] = init();
+  }
+
+  return global.__singletons[name] as T;
+}

--- a/src/utils/singleton.ts
+++ b/src/utils/singleton.ts
@@ -1,3 +1,6 @@
+// original code from https://github.com/jenseng/abuse-the-platform/blob/main/app/utils/singleton.ts
+// sourced from https://github.com/remix-run/blues-stack/blob/main/app/singleton.server.ts
+
 declare global {
   // must be var not let due to variable hoisting
   var __singletons: Record<string, unknown> | undefined; // eslint-disable-line


### PR DESCRIPTION
Right now there is no way to know if any given route is being imported because it's being used to generated a sitemap, or because it's actually being used for a server. Because of this it means if a server relies on workers, or opens a connection for logging, it will also do so when attempting to just generate a sitemap then shut down.

This causes the `npx remix-sitemap` command to hand infinitely, because of connectioned opened or workers started for functionality not used in generating a sitemap.

In this pr I've implemented a basic functioning flag system to allow apps using remix-sitemap to probe if it's been started purely for the purpose of sitemap generation:
```ts
import { getFlags } from "remix-sitemap";
const remixSitemapFlags = getFlags();

const bindings = remixSitemapFlags.standalone
	? {} as any as ReturnType<typeof InitializeWorker>
	: InitializeWorker();
```

I do not think the current function names or flag names should stay as is, but it's a MVP for something that would be helpful feature to be added