### PR TITLE
fix: app load context, global exclusions

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -46,7 +46,8 @@ async function main() {
         routes
       }
     },
-    request: {} as unknown as Request
+    request: {} as unknown as Request,
+    appContext: {},
   };
 
   const isSplitted = config.size && config.size > 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { sitemapResponse } from './sitemap';
 import { isSitemapUrl, isRobotsUrl } from './utils/validations';
 import { getConfig } from './lib/config';
 import { robotsResponse } from './robots';
+import { AppLoadContext } from '@remix-run/server-runtime';
 
 export {
   SitemapHandle,
@@ -16,9 +17,9 @@ export const createSitemapGenerator = (config: Config) => {
   const defaultConfig = getConfig(config);
 
   return {
-    sitemap: (request: Request, context: EntryContext) => {
+    sitemap: (request: Request, context: EntryContext, appContext: AppLoadContext) => {
       if (isSitemapUrl(defaultConfig, request)) {
-        return sitemapResponse(defaultConfig, request, context);
+        return sitemapResponse(defaultConfig, request, context, appContext);
       }
 
       if (defaultConfig.generateRobotsTxt && isRobotsUrl(request)) {
@@ -28,7 +29,7 @@ export const createSitemapGenerator = (config: Config) => {
 
     robots: () => robotsResponse(defaultConfig),
 
-    experimental_sitemap: (request: Request, routes: Routes) => {
+    experimental_sitemap: (request: Request, routes: Routes, appContext: AppLoadContext) => {
       const routeModules = Object.keys(routes).reduce(
         (acc, route) => ({
           ...acc,
@@ -42,7 +43,7 @@ export const createSitemapGenerator = (config: Config) => {
         manifest: {
           routes
         }
-      });
+      }, appContext);
     },
 
     isSitemapUrl: (request: Request) =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import { AppLoadContext } from "@remix-run/server-runtime";
+
 type ChangeFreq =
   | 'never'
   | 'yearly'
@@ -229,6 +231,7 @@ export type Policy = {
 export interface SitemapArgs {
   config: Config;
   request: Request;
+  context: AppLoadContext;
 }
 
 export type SitemapDefinition =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,11 @@ export interface RemixSitemapConfig {
    * The cache to use.
    */
   cache?: Cache;
+
+  /**
+   * Exclusions to apply.
+   */
+  exclusions?: RegExp[];
 }
 
 export interface Cache {

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -1,10 +1,12 @@
 import type { RemixSitemapConfig, EntryContext } from './lib/types';
 import { buildSitemap } from './builders/sitemap';
+import { AppLoadContext } from '@remix-run/server-runtime';
 
 export async function sitemapResponse(
   config: RemixSitemapConfig,
   request: Request,
-  context: EntryContext
+  context: EntryContext,
+  appContext: AppLoadContext,
 ) {
   const { cache } = config;
 
@@ -27,7 +29,8 @@ export async function sitemapResponse(
   const sitemap = await buildSitemap({
     config,
     context,
-    request
+    request,
+    appContext,
   });
 
   if (cache) await cache.set(sitemap);

--- a/src/utils/entries.ts
+++ b/src/utils/entries.ts
@@ -8,14 +8,14 @@ export type GetEntryParams = GetSitemapParams & {
 };
 
 export async function getEntry(params: GetEntryParams) {
-  const { route, context, request, config } = params;
+  const { route, context, request, config, appContext } = params;
 
   if (!isValidEntry(route, context)) return null;
 
   const { sitemapFunction, path } = getRouteData(route, context);
 
   const sitemap = sitemapFunction
-    ? await sitemapFunction({ request, config })
+    ? await sitemapFunction({ request, config, context: appContext })
     : null;
 
   if (sitemap) {


### PR DESCRIPTION
Fixes and closes fedeya/remix-sitemap#6. Also adds a global `exclusions` property, which accepts `RegExp[]` and excludes any routes that match.